### PR TITLE
Fix preview toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+main.min.css
+index.build.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 main.min.css
 index.build.js
+.dat

--- a/index.js
+++ b/index.js
@@ -177,10 +177,10 @@ async function generateFilePreview (archive, path) {
 
   if (lines.length > 10) {
     previewNote = `
-    <span data-preview="preview-${path.replace('.', '')}" class="preview-toggle-expand expand">
+    <span data-preview="preview-${path.replace(/\./g, '')}" class="preview-toggle-expand expand">
     + ${lines.length - 10} more lines...
     </span>
-      <span data-preview="preview-${path.replace('.', '')}" class="preview-toggle-expand collapse hidden">
+      <span data-preview="preview-${path.replace(/\./g, '')}" class="preview-toggle-expand collapse hidden">
         - Less
       </span>`
   }
@@ -188,7 +188,7 @@ async function generateFilePreview (archive, path) {
   return `
     <li class="file-preview">
       <a href=${path}>${path}</a>
-      <pre id="preview-${path}" class="preview ${previewNote ? 'more-lines' : ''} ${isMarkdown ? 'markdown' : ''}">${isMarkdown ? marked(file) : escape(file.trim())}</pre>
+      <pre id="preview-${path.replace(/\./g, '')}" class="preview ${previewNote ? 'more-lines' : ''} ${isMarkdown ? 'markdown' : ''}">${isMarkdown ? marked(file) : escape(file.trim())}</pre>
       ${previewNote}
     </li>`
 }


### PR DESCRIPTION
When the file name contained dot the id of the preview section
and the data attribute used in show more toggle link were not identical.
One used file name without dots, the other with dots.

I also changed the replace method to replace all dots, not only the
first one.

Changes in .gitignore to avoid accidentaly adding files during development. 