### PR TITLE
Removes depresciated .commit method

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,6 @@ async function createGist () {
         paths.push(path)
       }
     }
-    await archive.commit()
 
     // if the user didn't add an index.html, generate a preview page
     if (paths.indexOf('index.html') === -1) await createPreviewPage(archive)


### PR DESCRIPTION
.commit() method is depreciated
(see:dat://beakerbrowser.com/docs/apis/dat#commit)
and as @pfrazee clarified on irc, the method can be just removed